### PR TITLE
Check as well if array exists, that it is not empty

### DIFF
--- a/src/Resources/views/Page/show.html.twig
+++ b/src/Resources/views/Page/show.html.twig
@@ -22,7 +22,7 @@
         <div>{{ resource.content|raw }}</div>
     </div>
 
-    {% if null != resource.products %}
+    {% if resource.products is not empty %}
         {% include '@SyliusShop/Product/_horizontalList.html.twig' with {'products': resource.products} %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
When you add a product, then remove it, the resource.products array exists but is empty. Therefore it isn't equal to null.